### PR TITLE
Don't rely on 3rd party APIs for time

### DIFF
--- a/Operating System Deployment/Slack Message/Get-TSDuration.ps1
+++ b/Operating System Deployment/Slack Message/Get-TSDuration.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory = $true)]
     [ValidateSet('Start', 'End')]
@@ -10,10 +10,10 @@ $tsenv = New-Object -ComObject Microsoft.SMS.TSEnvironment
 
 # Set the Task Sequence Variable based on the parameter passed.
 if ($StartEnd -eq 'Start') {
-    $tsenv.Value('StartTime') = [datetime]::FromFileTimeUTC((Invoke-RestMethod -Uri 'http://worldclockapi.com/api/json/utc/now' -Method GET).currentFileTime)
+    $tsenv.Value('StartTime') = (get-date).ToUniversalTime()
     #Gets Logged In User for In-Place Upgrade Reporting
     $tsenv.Value('XLoggedInUser') = (Get-CimInstance –ClassName Win32_ComputerSystem | Select-Object UserName -ErrorAction SilentlyContinue).Username 
 }
 if ($StartEnd -eq 'End') {
-    $tsenv.Value('EndTime') = [datetime]::FromFileTimeUTC((Invoke-RestMethod -Uri 'http://worldclockapi.com/api/json/utc/now' -Method GET).currentFileTime)
+    $tsenv.Value('EndTime') = (get-date).ToUniversalTime()
 }


### PR DESCRIPTION
http://worldclockapi.com is offline and has been for a couple months so right now this script fails to execute.
I'm proposing that we just use PoSH's native Get-Date cmdlet to keep track of how much time has passed.
For StartTime and EndTime, we can use (get-date).ToUniversalTime() instead.